### PR TITLE
Fix for using jobber_mobile repo with dependabot

### DIFF
--- a/lib/library_version_analysis/github.rb
+++ b/lib/library_version_analysis/github.rb
@@ -106,7 +106,6 @@ module LibraryVersionAnalysis
         raise QueryExecutionError, response.errors[:data].join(", ")
       else
         end_cursor = add_results(response.data.repository.vulnerability_alerts, alerts, ecosystem)
-        end_cursor = nil # Until github issue is resolved.
         until end_cursor.nil?
           response = Github::CLIENT.query(AlertsQueryNext, variables: { name: github_name, cursor: end_cursor })
           end_cursor = add_results(response.data.repository.vulnerability_alerts, alerts, ecosystem)

--- a/lib/library_version_analysis/mobile.rb
+++ b/lib/library_version_analysis/mobile.rb
@@ -8,7 +8,7 @@ module LibraryVersionAnalysis
       end
 
       parsed_results, meta_data = parse_libyear(libyear_results)
-      LibraryVersionAnalysis::Github.new.get_dependabot_findings(parsed_results, meta_data, "Jobber", "NPM")
+      LibraryVersionAnalysis::Github.new.get_dependabot_findings(parsed_results, meta_data, "Jobber-mobile", "NPM")
       add_ownerships(parsed_results)
 
       return parsed_results, meta_data
@@ -125,6 +125,8 @@ module LibraryVersionAnalysis
 
         next if parent.nil?
 
+        binding.pry if parsed_results[parent].nil?
+
         if parsed_results[parent].owner == :unknown
           line_data.owner = :transitive_unspecified # note, this order is important, line_data and parsed_result[parent] could be the same thing
           parsed_results[parent].owner = :unspecified # in which case, we want :unspecified
@@ -152,15 +154,22 @@ module LibraryVersionAnalysis
       # ├ ─ ┬    │ ├ ─ ─   │ │ └ ─ ─ These are the symbols used, keep here for now
       parent = "undefined"
 
+      last_parent = false
       results.each_line do |line|
         scan_result = line.scan(/.* (.*)@(.*)/)
         next if scan_result.nil? || scan_result.empty?
 
         name = scan_result[0][0]
+
         current_version = scan_result[0][1]
         parsed_results[name].current_version = current_version unless parsed_results[name].nil?
 
-        parent = name if !name.nil? && (line.count("│").zero? || line[0] == "├")
+        if line.start_with?("└")
+          last_parent = true
+          parent = name
+        end
+
+        parent = name if !name.nil? && !last_parent && (line.count("│").zero? || line[0] == "├")
 
         mappings[name] = parent unless name.nil?
       end

--- a/lib/library_version_analysis/mobile.rb
+++ b/lib/library_version_analysis/mobile.rb
@@ -125,8 +125,6 @@ module LibraryVersionAnalysis
 
         next if parent.nil?
 
-        binding.pry if parsed_results[parent].nil?
-
         if parsed_results[parent].owner == :unknown
           line_data.owner = :transitive_unspecified # note, this order is important, line_data and parsed_result[parent] could be the same thing
           parsed_results[parent].owner = :unspecified # in which case, we want :unspecified

--- a/lib/library_version_analysis/version.rb
+++ b/lib/library_version_analysis/version.rb
@@ -1,3 +1,3 @@
 module LibraryVersionAnalysis
-  VERSION = "0.0.7".freeze
+  VERSION = "1.0.0".freeze
 end


### PR DESCRIPTION
We were using the wrong repo when getting dependabot warnings for jobber-mobile.

This PR also removes the hack put in place to work around a github API bug.