### PR TITLE
JOB-50544 fixed repo for online dependabot alerts

### DIFF
--- a/lib/library_version_analysis.rb
+++ b/lib/library_version_analysis.rb
@@ -2,7 +2,7 @@ require "library_version_analysis/analyze"
 require "library_version_analysis/check_version_status"
 require "library_version_analysis/github"
 require "library_version_analysis/online"
-require "library_version_analysis/mobile"
+require "library_version_analysis/npm"
 require "library_version_analysis/version"
 require "pry-byebug"
 

--- a/lib/library_version_analysis/check_version_status.rb
+++ b/lib/library_version_analysis/check_version_status.rb
@@ -58,16 +58,16 @@ module LibraryVersionAnalysis
 
     def go_online_node(spreadsheet_id)
       puts "  online node" if DEV_OUTPUT
-      mobile_node = Mobile.new
-      meta_data_online_node, mode_online_node = get_version_summary(mobile_node, "OnlineNodeVersionData!A:M", spreadsheet_id, "ONLINE NODE")
+      npm = Npm.new("Jobber")
+      meta_data_online_node, mode_online_node = get_version_summary(npm, "OnlineNodeVersionData!A:M", spreadsheet_id, "ONLINE NODE")
 
       return meta_data_online_node, mode_online_node
     end
 
     def go_mobile(spreadsheet_id)
       puts "  mobile" if DEV_OUTPUT
-      mobile = Mobile.new
-      meta_data_mobile, mode_mobile = get_version_summary(mobile, "MobileVersionData!A:M", spreadsheet_id, "MOBILE")
+      npm = Npm.new("Jobber-mobile")
+      meta_data_mobile, mode_mobile = get_version_summary(npm, "MobileVersionData!A:M", spreadsheet_id, "MOBILE")
 
       return meta_data_mobile, mode_mobile
     end

--- a/lib/library_version_analysis/npm.rb
+++ b/lib/library_version_analysis/npm.rb
@@ -1,5 +1,5 @@
 module LibraryVersionAnalysis
-  class Mobile
+  class Npm
     def get_versions
       libyear_results = run_libyear
       if libyear_results.nil?

--- a/lib/library_version_analysis/version.rb
+++ b/lib/library_version_analysis/version.rb
@@ -1,3 +1,3 @@
 module LibraryVersionAnalysis
-  VERSION = "0.0.7".freeze
+  VERSION = "1.0.1".freeze
 end

--- a/spec/npm_spec.rb
+++ b/spec/npm_spec.rb
@@ -1,6 +1,6 @@
 Status = Struct.new(:exitstatus)
 
-RSpec.describe LibraryVersionAnalysis::Mobile do
+RSpec.describe LibraryVersionAnalysis::Npm do
   let(:npxfile) do
     <<~DOC
       [
@@ -61,7 +61,7 @@ RSpec.describe LibraryVersionAnalysis::Mobile do
 
   context "when mobile" do
     subject do
-      analyzer = LibraryVersionAnalysis::Mobile.new
+      analyzer = LibraryVersionAnalysis::Npm.new
       allow(analyzer).to receive(:read_file).with("./libyear_report.txt", true).and_return(npxfile)
       allow(analyzer).to receive(:read_file).with("./package.json", false).and_return(packagefile)
       allow(analyzer).to receive(:run_npm_list).and_return(npmlist)


### PR DESCRIPTION
Was using jobber-mobile as repo when querying for online NPM dependabot alerts.