### PR TITLE
FEAT: Parameterize GitHub token environment variable

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+# See README for instructions on generating Github token
+GITHUB_READ_API_TOKEN=1234

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 .rspec_status
 *.iml
 Gemfile.lock
+
+.env.local

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in library_version_analysis.gemspec
 gemspec
 
+gem 'dotenv-rails', groups: [:development, :test]
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in library_version_analysis.gemspec
 gemspec
 
-gem 'dotenv-rails', groups: [:development, :test]
+gem 'dotenv-rails', "~> 2.8.1", groups: [:development, :test]
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
+To run the shell script locally, you must first set up the environment variables in the `.env.local` file.
+To generate the Github token, follow these steps:
+1. From any page on Github, click your icon at the top right, and click Settings
+2. Click Developer Settings in the left panel
+3. Click Personal Access Tokens and then `Tokens Classic`
+4. Click Generate New Token -> Generate new token (classic)
+5. Create a token with the `Repo` scope enabled
+
 ## Jobber Dev
 Update the gemfile to read:
 jgem :enablers, "library_version_analysis", path: "/Users/johnz/source/library_version_analysis"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ To generate the Github token, follow these steps:
 3. Click Personal Access Tokens and then `Tokens Classic`
 4. Click Generate New Token -> Generate new token (classic)
 5. Create a token with the `Repo` scope enabled
+6. Add the token to the `.env.local` file under the `GITHUB_READ_API_TOKEN` entry
 
 ## Jobber Dev
 Update the gemfile to read:

--- a/lib/library_version_analysis/github.rb
+++ b/lib/library_version_analysis/github.rb
@@ -1,5 +1,6 @@
 require "graphql/client"
 require "graphql/client/http"
+require 'dotenv/load'
 
 module LibraryVersionAnalysis
   class Github


### PR DESCRIPTION
# Description
Noticed that we currently have a manual setup for the API token in this repo, with no instructions and a need for manually setting the environment variable before loading the project.

This PR introduces the `dot-env` dependency which allows us to set the API token in a non-version-controlled file (`.env.local`) in a similar fashion to the Jobber Online repo. It also adds some instructions to the README for generating the Github token.