### PR TITLE
JOB-75360 Update pry to 0.14.2 for ruby 3.2.2

### DIFF
--- a/library_version_analysis.gemspec
+++ b/library_version_analysis.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "graphql-client"
   spec.add_dependency "libyear-bundler"
   spec.add_dependency "open3"
-  spec.add_dependency "pry", "~> 0.13.1"
+  spec.add_dependency "pry", "~> 0.14.2"
   spec.add_dependency "slack-ruby-client"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rspec", "~> 3.2"


### PR DESCRIPTION
In order to spike out, and eventually run, ruby 3.2.2 on Jobber online we need to update pry to be compatible with ruby 3.2. This gem is currently preventing the pry upgrade

When trying to update `pry` in Jobber online, we get:
![Screenshot 2023-08-08 at 12 46 39](https://github.com/GetJobber/library_version_analysis/assets/81261618/8b0ae077-6045-422f-ab19-b9a6f67ad815)
