### PR TITLE
Remove graphql dependency

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -34,3 +34,6 @@
 
 1.4.6
     Updated GQL library requirements.
+
+1.4.7
+    Removed graphql dependency.

--- a/lib/library_version_analysis/version.rb
+++ b/lib/library_version_analysis/version.rb
@@ -1,3 +1,3 @@
 module LibraryVersionAnalysis
-  VERSION = "1.4.6".freeze
+  VERSION = "1.4.7".freeze
 end

--- a/library_version_analysis.gemspec
+++ b/library_version_analysis.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'google-api-client'
   spec.add_dependency "googleauth"
-  spec.add_dependency "graphql", "~> 2.0.24"
   spec.add_dependency "graphql-client", "~> 0.18"
   spec.add_dependency "libyear-bundler"
   spec.add_dependency "open3"


### PR DESCRIPTION
Since we have a dependency for `graphq-client` we don't need the `graphql` dependency.