### PR TITLE
Remove pry

### DIFF
--- a/lib/csv_upload.rb
+++ b/lib/csv_upload.rb
@@ -1,7 +1,5 @@
 require "csv_upload/upload"
 
-require "pry-byebug"
-
 module CsvUpload
   class Error < StandardError; end
   # Your code goes here...

--- a/lib/library_version_analysis.rb
+++ b/lib/library_version_analysis.rb
@@ -5,7 +5,6 @@ require "library_version_analysis/gemfile"
 require "library_version_analysis/npm"
 require "library_version_analysis/version"
 require "library_version_analysis/slack_notify"
-require "pry-byebug"
 
 module LibraryVersionAnalysis
   class Error < StandardError; end

--- a/lib/library_version_analysis/check_version_status.rb
+++ b/lib/library_version_analysis/check_version_status.rb
@@ -1,6 +1,5 @@
 require "googleauth"
 require "google/apis/sheets_v4"
-require "pry-byebug"
 require "library_version_analysis/library_tracking"
 require "library_version_analysis/configuration"
 

--- a/lib/library_version_analysis/github.rb
+++ b/lib/library_version_analysis/github.rb
@@ -1,6 +1,5 @@
 require "graphql/client"
 require "graphql/client/http"
-require "pry-byebug"
 require "library_version_analysis/configuration"
 
 module LibraryVersionAnalysis

--- a/library_version_analysis.gemspec
+++ b/library_version_analysis.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "graphql-client", "~> 0.20"
   spec.add_dependency "libyear-bundler"
   spec.add_dependency "open3"
-  spec.add_dependency "pry", "~> 0.14.2"
   spec.add_dependency "slack-ruby-client"
   spec.add_dependency "code_ownership"
   spec.add_development_dependency "pry-byebug"


### PR DESCRIPTION
We are getting `pry` deprecations in the main app and we have two options:

1. Update `pry` in the main app and all depdencies
2. Remove `pry` and just use `irb`

We're going to experiment with `2`!