### PR TITLE
JOB-116022 Update pry

### DIFF
--- a/library_version_analysis.gemspec
+++ b/library_version_analysis.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "graphql-client", "~> 0.20"
   spec.add_dependency "libyear-bundler"
   spec.add_dependency "open3"
-  spec.add_dependency "pry", "~> 0.14.2"
+  spec.add_dependency "pry", "~> 0.15.2"
   spec.add_dependency "slack-ruby-client"
   spec.add_dependency "code_ownership"
   spec.add_development_dependency "pry-byebug"


### PR DESCRIPTION
We're getting the following deprecation in Jobber Online:

![image](https://github.com/user-attachments/assets/d74a5778-1126-412f-8cd9-874d83212f58)

Bumping to the latest version of `pry` will allow us to update it as well in Jobber Online:

<img width="666" alt="image" src="https://github.com/user-attachments/assets/5d60690c-082b-41ed-8035-854e44539214" />