### PR TITLE
JOB-148890 Dependabot alerts leaking across pnpm workspaces

### DIFF
--- a/lib/library_version_analysis/pnpm.rb
+++ b/lib/library_version_analysis/pnpm.rb
@@ -123,6 +123,7 @@ module LibraryVersionAnalysis
 
       puts("\tPNPM [#{source}] dependabot") if LibraryVersionAnalysis.dev_output?
       add_dependabot_findings(parsed_results, meta_data, @github_repo, "pnpm")
+      filter_to_workspace_packages(parsed_results, all_libraries, source)
 
       puts("\tPNPM [#{source}] building dependency graph") if LibraryVersionAnalysis.dev_output?
       add_dependency_graph(parsed_results, workspace_path)
@@ -156,6 +157,7 @@ module LibraryVersionAnalysis
 
       puts("\tPNPM dependabot") if LibraryVersionAnalysis.dev_output?
       add_dependabot_findings(parsed_results, meta_data, @github_repo, source)
+      filter_to_workspace_packages(parsed_results, all_libraries, source)
 
       puts("\tPNPM building dependency graph") if LibraryVersionAnalysis.dev_output?
       add_dependency_graph(parsed_results)
@@ -211,6 +213,14 @@ module LibraryVersionAnalysis
     end
 
     private
+
+    def filter_to_workspace_packages(parsed_results, all_libraries, source)
+      injected = parsed_results.keys.reject { |name| all_libraries.has_key?(name) }
+      return if injected.empty?
+
+      puts("\tPNPM [#{source}] removing #{injected.count} Dependabot alerts not in this workspace") if LibraryVersionAnalysis.dev_output?
+      injected.each { |name| parsed_results.delete(name) }
+    end
 
     def run_libyear
       # Ideally, we'd run the "pnpx libyear --package-manager pnpm --all --json" command from here.

--- a/spec/pnpm_spec.rb
+++ b/spec/pnpm_spec.rb
@@ -643,6 +643,97 @@ RSpec.describe LibraryVersionAnalysis::Pnpm do
     end
   end
 
+  describe "#filter_to_workspace_packages" do
+    let(:analyzer) { LibraryVersionAnalysis::Pnpm.new("test") }
+
+    it "should remove Dependabot-injected packages not in the workspace dependency tree" do
+      all_libraries = {
+        "react" => LibraryVersionAnalysis::Versionline.new(owner: ":unknown", current_version: "18.2.0"),
+        "lodash" => LibraryVersionAnalysis::Versionline.new(owner: ":unknown", current_version: "4.17.21")
+      }
+
+      parsed_results = {
+        "react" => LibraryVersionAnalysis::Versionline.new(owner: ":unknown", current_version: "18.2.0"),
+        "lodash" => LibraryVersionAnalysis::Versionline.new(owner: ":unknown", current_version: "4.17.21"),
+        "@grpc/grpc-js" => LibraryVersionAnalysis::Versionline.new(
+          owner: LibraryVersionAnalysis::Configuration.get(:default_owner_name),
+          current_version: "?",
+          major: 0, minor: 0, patch: 0, age: 0,
+          vulnerabilities: [LibraryVersionAnalysis::Vulnerability.new(identifier: ["CVE-2024-37168"], assigned_severity: "MODERATE")]
+        )
+      }
+
+      analyzer.send(:filter_to_workspace_packages, parsed_results, all_libraries, "packages/visualizations")
+
+      expect(parsed_results).to have_key("react")
+      expect(parsed_results).to have_key("lodash")
+      expect(parsed_results).not_to have_key("@grpc/grpc-js")
+    end
+
+    it "should not remove any packages when all are in the workspace" do
+      all_libraries = {
+        "react" => LibraryVersionAnalysis::Versionline.new(owner: ":unknown", current_version: "18.2.0"),
+        "lodash" => LibraryVersionAnalysis::Versionline.new(owner: ":unknown", current_version: "4.17.21")
+      }
+
+      parsed_results = {
+        "react" => LibraryVersionAnalysis::Versionline.new(owner: ":unknown", current_version: "18.2.0"),
+        "lodash" => LibraryVersionAnalysis::Versionline.new(owner: ":unknown", current_version: "4.17.21")
+      }
+
+      analyzer.send(:filter_to_workspace_packages, parsed_results, all_libraries, "packages/visualizations")
+
+      expect(parsed_results.keys).to contain_exactly("react", "lodash")
+    end
+
+    it "should keep vulnerable packages that are actually in the workspace" do
+      all_libraries = {
+        "react" => LibraryVersionAnalysis::Versionline.new(owner: ":unknown", current_version: "18.2.0"),
+        "vulnerable-lib" => LibraryVersionAnalysis::Versionline.new(owner: ":unknown", current_version: "1.0.0")
+      }
+
+      parsed_results = {
+        "react" => LibraryVersionAnalysis::Versionline.new(owner: ":unknown", current_version: "18.2.0"),
+        "vulnerable-lib" => LibraryVersionAnalysis::Versionline.new(
+          owner: ":unknown", current_version: "1.0.0",
+          vulnerabilities: [LibraryVersionAnalysis::Vulnerability.new(identifier: ["CVE-2024-00001"], assigned_severity: "HIGH")]
+        )
+      }
+
+      analyzer.send(:filter_to_workspace_packages, parsed_results, all_libraries, "packages/visualizations")
+
+      expect(parsed_results).to have_key("vulnerable-lib")
+      expect(parsed_results["vulnerable-lib"].vulnerabilities).not_to be_empty
+    end
+
+    it "should handle empty parsed_results" do
+      all_libraries = {}
+      parsed_results = {}
+
+      analyzer.send(:filter_to_workspace_packages, parsed_results, all_libraries, "root")
+
+      expect(parsed_results).to be_empty
+    end
+
+    it "should remove multiple injected packages from different workspaces" do
+      all_libraries = {
+        "react" => LibraryVersionAnalysis::Versionline.new(owner: ":unknown", current_version: "18.2.0")
+      }
+
+      parsed_results = {
+        "react" => LibraryVersionAnalysis::Versionline.new(owner: ":unknown", current_version: "18.2.0"),
+        "@grpc/grpc-js" => LibraryVersionAnalysis::Versionline.new(owner: ":unknown", current_version: "?",
+          vulnerabilities: [LibraryVersionAnalysis::Vulnerability.new(identifier: ["CVE-2024-37168"], assigned_severity: "MODERATE")]),
+        "some-other-vuln" => LibraryVersionAnalysis::Versionline.new(owner: ":unknown", current_version: "?",
+          vulnerabilities: [LibraryVersionAnalysis::Vulnerability.new(identifier: ["CVE-2024-99999"], assigned_severity: "HIGH")])
+      }
+
+      analyzer.send(:filter_to_workspace_packages, parsed_results, all_libraries, "packages/visualizations")
+
+      expect(parsed_results.keys).to contain_exactly("react")
+    end
+  end
+
   describe "#add_ownerships with workspace_path" do
     let(:analyzer) { LibraryVersionAnalysis::Pnpm.new("test") }
 


### PR DESCRIPTION
## Summary

- Fixes a scope mismatch where Dependabot alerts fetched at **repository level** were being injected into **every workspace's** results, even when the vulnerable package doesn't belong to that workspace
- Adds a `filter_to_workspace_packages` method that removes Dependabot-injected packages not present in the workspace's dependency tree (`all_libraries` from `pnpm list`)
- Applied to both `get_versions_for_workspace` (per-workspace path) and `get_versions` (legacy single-package path)

## Problem

When analyzing pnpm workspaces, the Dependabot API query (`github.rb`) fetches all NPM alerts for the entire repository. For a vulnerable package like `@grpc/grpc-js` that belongs to workspace X, the alert would also be injected into workspace Y's `parsed_results`. Since `@grpc/grpc-js` is not in workspace Y's dependency tree:

1. No `LibNode` / dependency graph is created for it
2. Transitive ownership can't walk any parent chain (graph is `nil`)
3. The package falls through to `attention_needed`
4. A false Slack notification is sent for a workspace that doesn't even use the package

## Fix

After `add_dependabot_findings` runs, `filter_to_workspace_packages` compares `parsed_results` keys against `all_libraries` (the complete set of packages from `pnpm list --depth=Infinity` for that workspace). Any package not in `all_libraries` — meaning it was injected by Dependabot but doesn't exist in this workspace — is removed from `parsed_results` before the dependency graph and ownership passes run.

## Test plan

- [x] Added 5 new RSpec tests for `filter_to_workspace_packages`:
  - Removes Dependabot-injected packages not in the workspace (core scenario with `@grpc/grpc-js`)
  - No-op when all packages belong to the workspace
  - Keeps vulnerable packages that are actually in the workspace
  - Handles empty `parsed_results`
  - Removes multiple injected packages from different workspaces
- [x] All 47 existing + new tests pass (`bundle exec rspec spec/pnpm_spec.rb`)
- [ ] Run against `jobber-frontend` to verify `@grpc/grpc-js` no longer appears in `packages/visualizations` results
- [ ] Verify `@grpc/grpc-js` still appears in whichever workspace actually depends on it


Made with [Cursor](https://cursor.com)