### PR TITLE
JOB-148890 Fix dependency duplication

### DIFF
--- a/lib/library_version_analysis/pnpm.rb
+++ b/lib/library_version_analysis/pnpm.rb
@@ -120,10 +120,13 @@ module LibraryVersionAnalysis
 
       puts("\tPNPM [#{source}] parsing libyear") if LibraryVersionAnalysis.dev_output?
       parsed_results, meta_data = parse_libyear(libyear_results, all_libraries)
+      # Snapshot before Dependabot: parse_libyear returns all_libraries as parsed_results (same object),
+      # so any keys Dependabot injects into parsed_results also appear in all_libraries.
+      workspace_package_names = parsed_results.keys.to_set
 
       puts("\tPNPM [#{source}] dependabot") if LibraryVersionAnalysis.dev_output?
       add_dependabot_findings(parsed_results, meta_data, @github_repo, "pnpm")
-      filter_to_workspace_packages(parsed_results, all_libraries, source)
+      filter_to_workspace_packages(parsed_results, workspace_package_names, source)
 
       puts("\tPNPM [#{source}] building dependency graph") if LibraryVersionAnalysis.dev_output?
       add_dependency_graph(parsed_results, workspace_path)
@@ -154,10 +157,13 @@ module LibraryVersionAnalysis
 
       puts("\tPNPM parsing libyear") if LibraryVersionAnalysis.dev_output?
       parsed_results, meta_data = parse_libyear(libyear_results, all_libraries)
+      # Snapshot before Dependabot: parse_libyear returns all_libraries as parsed_results (same object),
+      # so any keys Dependabot injects into parsed_results also appear in all_libraries.
+      workspace_package_names = parsed_results.keys.to_set
 
       puts("\tPNPM dependabot") if LibraryVersionAnalysis.dev_output?
       add_dependabot_findings(parsed_results, meta_data, @github_repo, source)
-      filter_to_workspace_packages(parsed_results, all_libraries, source)
+      filter_to_workspace_packages(parsed_results, workspace_package_names, source)
 
       puts("\tPNPM building dependency graph") if LibraryVersionAnalysis.dev_output?
       add_dependency_graph(parsed_results)
@@ -196,6 +202,7 @@ module LibraryVersionAnalysis
 
       packages.each do |package|
         all_nodes = build_dependency_graph(all_nodes, package["dependencies"], nil)
+        all_nodes = build_dependency_graph(all_nodes, package["devDependencies"], nil)
       end
 
       missing_keys = {} # TODO: handle missing keys
@@ -214,8 +221,8 @@ module LibraryVersionAnalysis
 
     private
 
-    def filter_to_workspace_packages(parsed_results, all_libraries, source)
-      injected = parsed_results.keys.reject { |name| all_libraries.has_key?(name) }
+    def filter_to_workspace_packages(parsed_results, workspace_package_names, source)
+      injected = parsed_results.keys.reject { |name| workspace_package_names.include?(name) }
       return if injected.empty?
 
       puts("\tPNPM [#{source}] removing #{injected.count} Dependabot alerts not in this workspace") if LibraryVersionAnalysis.dev_output?
@@ -275,9 +282,9 @@ module LibraryVersionAnalysis
     def add_all_libraries(workspace_path = nil) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       all_libraries = {}
       cmd = if workspace_path
-              "pnpm list --dir #{workspace_path} --depth=Infinity --silent"
+              "pnpm list --dir #{workspace_path} --depth=0 --silent"
             else
-              "pnpm list --depth=Infinity --silent"
+              "pnpm list --depth=0 --silent"
             end
 
       results, _stderr, _status = Open3.capture3(cmd)

--- a/spec/pnpm_spec.rb
+++ b/spec/pnpm_spec.rb
@@ -269,6 +269,78 @@ RSpec.describe LibraryVersionAnalysis::Pnpm do
       expect(result["d"]).not_to be_nil
     end
 
+    it "should build graph from devDependencies when no dependencies exist" do
+      pnpm_dev_only = <<~DOC
+        [
+          {
+            "name": "workspace-pkg",
+            "version": "1.0.0",
+            "devDependencies": {
+              "a": {
+                "version": "1.0.0",
+                "dependencies": {
+                  "b": {
+                    "version": "2.0.0"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      DOC
+
+      parsed_results = { "a" => {}, "b" => {} }
+
+      analyzer = LibraryVersionAnalysis::Pnpm.new("test")
+      allow(analyzer).to receive(:run_pnpm_list).and_return(pnpm_dev_only)
+      result = analyzer.add_dependency_graph(parsed_results)
+
+      expect(result.count).to eq(2)
+      expect(result["b"].parents[0].name).to eq("a")
+    end
+
+    it "should build graph from both dependencies and devDependencies" do
+      pnpm_mixed = <<~DOC
+        [
+          {
+            "name": "workspace-pkg",
+            "version": "1.0.0",
+            "dependencies": {
+              "a": {
+                "version": "1.0.0",
+                "dependencies": {
+                  "shared": {
+                    "version": "3.0.0"
+                  }
+                }
+              }
+            },
+            "devDependencies": {
+              "b": {
+                "version": "2.0.0",
+                "dependencies": {
+                  "shared": {
+                    "version": "3.0.0"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      DOC
+
+      parsed_results = { "a" => {}, "b" => {}, "shared" => {} }
+
+      analyzer = LibraryVersionAnalysis::Pnpm.new("test")
+      allow(analyzer).to receive(:run_pnpm_list).and_return(pnpm_mixed)
+      result = analyzer.add_dependency_graph(parsed_results)
+
+      expect(result.count).to eq(3)
+      expect(result["shared"].parents.count).to eq(2)
+      parent_names = result["shared"].parents.map(&:name)
+      expect(parent_names).to contain_exactly("a", "b")
+    end
+
     it "should gracefully handle pnpm list failure" do
       parsed_results = { "a" => {}, "b" => {} }
 
@@ -647,10 +719,7 @@ RSpec.describe LibraryVersionAnalysis::Pnpm do
     let(:analyzer) { LibraryVersionAnalysis::Pnpm.new("test") }
 
     it "should remove Dependabot-injected packages not in the workspace dependency tree" do
-      all_libraries = {
-        "react" => LibraryVersionAnalysis::Versionline.new(owner: ":unknown", current_version: "18.2.0"),
-        "lodash" => LibraryVersionAnalysis::Versionline.new(owner: ":unknown", current_version: "4.17.21")
-      }
+      workspace_package_names = Set["react", "lodash"]
 
       parsed_results = {
         "react" => LibraryVersionAnalysis::Versionline.new(owner: ":unknown", current_version: "18.2.0"),
@@ -663,7 +732,7 @@ RSpec.describe LibraryVersionAnalysis::Pnpm do
         )
       }
 
-      analyzer.send(:filter_to_workspace_packages, parsed_results, all_libraries, "packages/visualizations")
+      analyzer.send(:filter_to_workspace_packages, parsed_results, workspace_package_names, "packages/visualizations")
 
       expect(parsed_results).to have_key("react")
       expect(parsed_results).to have_key("lodash")
@@ -671,26 +740,20 @@ RSpec.describe LibraryVersionAnalysis::Pnpm do
     end
 
     it "should not remove any packages when all are in the workspace" do
-      all_libraries = {
-        "react" => LibraryVersionAnalysis::Versionline.new(owner: ":unknown", current_version: "18.2.0"),
-        "lodash" => LibraryVersionAnalysis::Versionline.new(owner: ":unknown", current_version: "4.17.21")
-      }
+      workspace_package_names = Set["react", "lodash"]
 
       parsed_results = {
         "react" => LibraryVersionAnalysis::Versionline.new(owner: ":unknown", current_version: "18.2.0"),
         "lodash" => LibraryVersionAnalysis::Versionline.new(owner: ":unknown", current_version: "4.17.21")
       }
 
-      analyzer.send(:filter_to_workspace_packages, parsed_results, all_libraries, "packages/visualizations")
+      analyzer.send(:filter_to_workspace_packages, parsed_results, workspace_package_names, "packages/visualizations")
 
       expect(parsed_results.keys).to contain_exactly("react", "lodash")
     end
 
     it "should keep vulnerable packages that are actually in the workspace" do
-      all_libraries = {
-        "react" => LibraryVersionAnalysis::Versionline.new(owner: ":unknown", current_version: "18.2.0"),
-        "vulnerable-lib" => LibraryVersionAnalysis::Versionline.new(owner: ":unknown", current_version: "1.0.0")
-      }
+      workspace_package_names = Set["react", "vulnerable-lib"]
 
       parsed_results = {
         "react" => LibraryVersionAnalysis::Versionline.new(owner: ":unknown", current_version: "18.2.0"),
@@ -700,25 +763,23 @@ RSpec.describe LibraryVersionAnalysis::Pnpm do
         )
       }
 
-      analyzer.send(:filter_to_workspace_packages, parsed_results, all_libraries, "packages/visualizations")
+      analyzer.send(:filter_to_workspace_packages, parsed_results, workspace_package_names, "packages/visualizations")
 
       expect(parsed_results).to have_key("vulnerable-lib")
       expect(parsed_results["vulnerable-lib"].vulnerabilities).not_to be_empty
     end
 
     it "should handle empty parsed_results" do
-      all_libraries = {}
+      workspace_package_names = Set[]
       parsed_results = {}
 
-      analyzer.send(:filter_to_workspace_packages, parsed_results, all_libraries, "root")
+      analyzer.send(:filter_to_workspace_packages, parsed_results, workspace_package_names, "root")
 
       expect(parsed_results).to be_empty
     end
 
     it "should remove multiple injected packages from different workspaces" do
-      all_libraries = {
-        "react" => LibraryVersionAnalysis::Versionline.new(owner: ":unknown", current_version: "18.2.0")
-      }
+      workspace_package_names = Set["react"]
 
       parsed_results = {
         "react" => LibraryVersionAnalysis::Versionline.new(owner: ":unknown", current_version: "18.2.0"),
@@ -728,9 +789,32 @@ RSpec.describe LibraryVersionAnalysis::Pnpm do
           vulnerabilities: [LibraryVersionAnalysis::Vulnerability.new(identifier: ["CVE-2024-99999"], assigned_severity: "HIGH")])
       }
 
-      analyzer.send(:filter_to_workspace_packages, parsed_results, all_libraries, "packages/visualizations")
+      analyzer.send(:filter_to_workspace_packages, parsed_results, workspace_package_names, "packages/visualizations")
 
       expect(parsed_results.keys).to contain_exactly("react")
+    end
+
+    it "should filter correctly even when Dependabot mutates the same hash object" do
+      # Simulates the real production flow: parse_libyear returns all_libraries as
+      # parsed_results (same object). The snapshot of keys must be taken before
+      # add_dependabot_findings mutates the hash, otherwise the filter is a no-op.
+      shared_hash = {
+        "react" => LibraryVersionAnalysis::Versionline.new(owner: ":unknown", current_version: "18.2.0"),
+        "lodash" => LibraryVersionAnalysis::Versionline.new(owner: ":unknown", current_version: "4.17.21")
+      }
+      workspace_package_names = shared_hash.keys.to_set
+
+      # Simulate what add_dependabot_findings does: inject cross-workspace packages
+      shared_hash["@grpc/grpc-js"] = LibraryVersionAnalysis::Versionline.new(
+        owner: ":unknown", current_version: "?",
+        vulnerabilities: [LibraryVersionAnalysis::Vulnerability.new(identifier: ["CVE-2024-37168"], assigned_severity: "MODERATE")]
+      )
+
+      analyzer.send(:filter_to_workspace_packages, shared_hash, workspace_package_names, "packages/visualizations")
+
+      expect(shared_hash).to have_key("react")
+      expect(shared_hash).to have_key("lodash")
+      expect(shared_hash).not_to have_key("@grpc/grpc-js")
     end
   end
 


### PR DESCRIPTION
## Summary

Three bugs fixed:

- **Workspace filter was a no-op due to object aliasing**: `parse_libyear()` returns the same hash object it receives as `all_libraries`, so `parsed_results` and `all_libraries` are the same reference. When `add_dependabot_findings` injects cross-workspace packages into `parsed_results`, they simultaneously appear in `all_libraries`, making the filter compare the hash against itself. Fix: snapshot known package names into an immutable `Set` before Dependabot mutates the hash.

- **Dependency graph empty for devDependency-only workspaces**: `pnpm list --json` puts devDependencies under a separate `"devDependencies"` key, not under `"dependencies"`. Workspace packages that only have devDependencies (like library packages with peerDependencies + devDependencies, e.g. `packages/visualizations`) produced an empty dependency graph, so transitive ownership propagation never ran and all transitive deps were uploaded as `owner: unknown`. Fix: process both `"dependencies"` and `"devDependencies"` from the JSON output.

- **Transitive dependency inflation**: `add_all_libraries` used `--depth=Infinity`, pulling the entire transitive dependency tree into `parsed_results` as top-level library records. This caused hundreds of transitive deps to be uploaded as individual libraries (e.g. 588 for `packages/visualizations` which only has 23 direct deps). Transitive deps should only exist in the dependency graph for ownership propagation, not as standalone library records. Fix: use `--depth=0` to only collect direct dependencies.

## Changes

| File | Change |
|------|--------|
| `lib/library_version_analysis/pnpm.rb` | Snapshot `parsed_results.keys.to_set` before Dependabot; update `filter_to_workspace_packages` to check against the `Set`; process `package["devDependencies"]` in `add_dependency_graph`; change `add_all_libraries` from `--depth=Infinity` to `--depth=0` |
| `spec/pnpm_spec.rb` | Update 5 existing filter tests to pass a `Set`; add 1 regression test for aliasing bug; add 2 tests for devDependencies graph building |

## Test plan

- [x] All 109 tests pass
- [x] Regression test covers the exact production aliasing scenario
- [x] New tests cover devDependencies-only and mixed dependency graph building
- [ ] Deploy and verify `packages/visualizations` uploads ~23 libraries (direct deps) instead of ~588
- [ ] Verify transitive ownership propagation works for devDependency-only workspace packages
- [ ] Verify no duplicate Slack notifications from cross-workspace Dependabot alerts