### PR TITLE
Update workflow actions for Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         ruby-version: ['3.3.6']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
## What's in this PR?

Updates the CI workflow to `actions/checkout@v6`.

### Before

The touched workflows still relied on older action majors.

### After

The touched workflows now use Node 24-ready action majors.

## QA Instructions

1. Confirm the touched workflow files now use the updated action majors.
2. Confirm any new version-file reference points at an existing `.nvmrc` or `.ruby-version`.
3. Let the PR workflow runs start and verify the touched jobs still bootstrap successfully.
4. Validation run locally: parsed modified workflow YAML with Ruby/Psych.

## References

- https://github.com/actions/checkout/releases/tag/v6.0.0

## ⚠️ Missing PR template

This repository does not define `.github/PULL_REQUEST_TEMPLATE.md`. Please add one so future PRs stay consistent.