### PR TITLE
JOB-172614 Update `pry` to allow unblock Ruby 4.0

### DIFF
--- a/library_version_analysis.gemspec
+++ b/library_version_analysis.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "graphql-client", "~> 0.20"
   spec.add_dependency "libyear-bundler"
   spec.add_dependency "open3"
-  spec.add_dependency "pry", "~> 0.15.2"
+  spec.add_dependency "pry", "~> 0.16.0"
   spec.add_dependency "slack-ruby-client"
   spec.add_dependency "code_ownership"
   spec.add_development_dependency "pry-byebug"


### PR DESCRIPTION
The current version of `pry` has a dependency on the `readline` gem which is a default gem in Ruby < 4. With the release of Ruby 4.0, the `readline` gem has been "promoted" to become a bundled gem because Ruby is swapping to use `reline` in it's place -- a Ruby only rewrite to avoid requiring the readline binary.

How this matters for us, `pry ~> 0.15` depends on `readline`. So to get to Ruby 4 we have two options: explicity include `readline` in the Gemfile, or update `pry` to a version that depends  on `reline`. This is the second approach

* [pry changelog](https://github.com/pry/pry/blob/master/CHANGELOG.md#v0160-december-26-2025)
* The [pry-byebug issue](https://github.com/deivid-rodriguez/pry-byebug/issues/460) that led me this way
* [Ruby docs](https://rubyreferences.github.io/rubychanges/4.0.html#default-gems-that-became-bundled) mentioning this gem

> [!NOTE]
> Upgrading Pry to 0.16 drops support for Ruby 2.6 