### PR TITLE
LIBTRACK-137 Resolve gemspec ownership from owned_globs, not CODEOWNERS

### DIFF
--- a/lib/library_version_analysis/gemfile.rb
+++ b/lib/library_version_analysis/gemfile.rb
@@ -196,6 +196,17 @@ module LibraryVersionAnalysis
       default_owner = LibraryVersionAnalysis::Configuration.get(:default_owner_name)
 
       Dir.glob(File.join("gems", "**", "*.gemspec")) do |gemspec_file|
+        # from_codeowners: false resolves ownership from the team owned_globs config
+        # rather than the generated .github/CODEOWNERS file. Repos that hand-curate
+        # CODEOWNERS (skip_codeowners_validation) otherwise return nil for every gem.
+        team = CodeOwnership.for_file(gemspec_file, from_codeowners: false)
+        if team.nil?
+          warn "No code owner for #{gemspec_file}; skipping gemspec ownership assignment"
+          next
+        end
+
+        group = team.raw_hash["group"]
+
         File.foreach(gemspec_file) do |line|
           scan_result = line.scan(/spec.add_.*dependency\s*"(\S*)"/)
 
@@ -204,8 +215,6 @@ module LibraryVersionAnalysis
           library = scan_result[0][0]
           next if(parsed_results.has_key?(library) && parsed_results[library].owner != default_owner)
 
-          team = CodeOwnership.for_file(gemspec_file)
-          group = team.raw_hash["group"]
           parsed_results[library]&.owner = group.start_with?(":") ? group : ":#{group}"
         end
       end

--- a/spec/gemfile_spec.rb
+++ b/spec/gemfile_spec.rb
@@ -130,6 +130,58 @@ RSpec.describe LibraryVersionAnalysis::Gemfile do
       allow(LibraryVersionAnalysis::CheckVersionStatus).to receive(:legacy?).and_return(false)
     end
 
+    describe "#add_ownership_from_gemspecs" do
+      let(:analyzer) { LibraryVersionAnalysis::Gemfile.new("test") }
+      let(:gemspec_contents) do
+        <<~DOC
+          spec.add_dependency "aasm"
+          spec.add_development_dependency "packwerk"
+        DOC
+      end
+
+      before(:each) do
+        allow(LibraryVersionAnalysis::Configuration).to receive(:get).and_call_original
+        allow(LibraryVersionAnalysis::Configuration).to receive(:get)
+          .with(:default_owner_name).and_return(:unspecified)
+        allow(Dir).to receive(:glob).and_call_original
+        allow(Dir).to receive(:glob).with(File.join("gems", "**", "*.gemspec"))
+          .and_yield("gems/example/example.gemspec")
+        allow(File).to receive(:foreach).and_call_original
+        allow(File).to receive(:foreach).with("gems/example/example.gemspec")
+          .and_yield('spec.add_dependency "aasm"')
+          .and_yield('spec.add_development_dependency "packwerk"')
+      end
+
+      it "assigns the gemspec owner's group to each dependency" do
+        team = double("team", raw_hash: { "group" => "self_serve" })
+        allow(CodeOwnership).to receive(:for_file)
+          .with("gems/example/example.gemspec", from_codeowners: false).and_return(team)
+
+        parsed_results = {
+          "aasm" => LibraryVersionAnalysis::Versionline.new(owner: :unspecified),
+          "packwerk" => LibraryVersionAnalysis::Versionline.new(owner: :unspecified),
+        }
+
+        analyzer.send(:add_ownership_from_gemspecs, parsed_results)
+
+        expect(parsed_results["aasm"].owner).to eq(":self_serve")
+        expect(parsed_results["packwerk"].owner).to eq(":self_serve")
+      end
+
+      it "skips the gemspec without raising when it has no code owner" do
+        allow(CodeOwnership).to receive(:for_file)
+          .with("gems/example/example.gemspec", from_codeowners: false).and_return(nil)
+
+        parsed_results = {
+          "aasm" => LibraryVersionAnalysis::Versionline.new(owner: :unspecified),
+        }
+
+        expect { analyzer.send(:add_ownership_from_gemspecs, parsed_results) }
+          .not_to raise_error
+        expect(parsed_results["aasm"].owner).to eq(:unspecified)
+      end
+    end
+
     describe "#add_dependency_graph" do
       it "should reverse simple chain" do
         c = SpecSetStruct.new(name: "c")


### PR DESCRIPTION
## What's in this PR?

The nightly gemfile analysis was crashing before it uploaded anything to Library Tracking, which is why the Jobber gemfile project stopped updating.

`add_ownership_from_gemspecs` resolves a code owner for every `gems/**/*.gemspec` via `CodeOwnership.for_file`, then reads `team.raw_hash`. The call was returning `nil`, so `nil.raw_hash` raised `undefined method 'raw_hash' for nil`. Because this runs near the end of the gemfile pass, the exception bubbled up and killed the whole `static_analysis:code_analyzer` rake task before `LibraryTracking.upload` ran.

**Root cause:** `code_ownership` 2.x changed `CodeOwnership.for_file` to default to `from_codeowners: true`, resolving ownership from the generated `.github/CODEOWNERS` file. Jobber hand-curates CODEOWNERS (`skip_codeowners_validation: true`), so it has no `gems/**` entries — and `for_file` returned `nil` for every gemspec. The gemspecs themselves are correctly owned via team `owned_globs`.

This passes `from_codeowners: false` so ownership is resolved from the `owned_globs` config (all Jobber gemspecs resolve to a team). It also resolves the owner once per gemspec and skips with a warning if a gemspec ever genuinely has no owner, so a single unowned file can't crash the whole run again.

## QA Instructions

- With a hand-curated CODEOWNERS that omits `gems/**`, the gemfile analysis no longer crashes and assigns each gem dependency its gemspec owner's group (resolved from `owned_globs`).
- A gemspec with no resolvable owner is skipped with a warning naming the file, rather than aborting the run.
- After a nightly run, the Jobber gemfile project receives an update in Library Tracking.

## References

- [LIBTRACK-137](https://jobber.atlassian.net/browse/LIBTRACK-137)
- Regression introduced by the `code_ownership` 2.x bump (GetJobber/Jobber#72435)

---
Co-Authored-By: Amplify 2.1.3 <amplify@getjobber.com>


[LIBTRACK-137]: https://jobber.atlassian.net/browse/LIBTRACK-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ