### PR TITLE
JOB-172698 Bump version to v2.0.2

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -37,3 +37,6 @@
 
 1.4.7
     Removed graphql dependency.
+
+2.0.2
+    Made robust to missing gemspec ownership.

--- a/lib/library_version_analysis/version.rb
+++ b/lib/library_version_analysis/version.rb
@@ -1,3 +1,3 @@
 module LibraryVersionAnalysis
-  VERSION = "2.0.0".freeze
+  VERSION = "2.0.2".freeze
 end


### PR DESCRIPTION
## Summary
Bumps the gem version to `2.0.2` and adds a CHANGELOG entry. This is the source of the new `v2.0.2` tag that the consuming repos (Jobber, jobber-frontend, library_tracking, jobber-mobile) reference.

- `version.rb`: `2.0.0` → `2.0.2`
- `CHANGELOG.MD`: `2.0.2 — Made robust to missing gemspec ownership.`

## Ordering
⚠️ **Merge this PR first, then create/push the `v2.0.2` tag.** The consuming repos pin to `tag: v2.0.2`; their Gemfile.lock files will be updated once the tag exists.

[JOB-172698](https://jobber.atlassian.net/browse/JOB-172698)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Co-Authored-By: Amplify 2.1.3 <amplify@getjobber.com>

[JOB-172698]: https://jobber.atlassian.net/browse/JOB-172698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ