### PR TITLE
LIBTRACK-138 Bump gem version to 2.0.3

### DIFF
--- a/lib/library_version_analysis/version.rb
+++ b/lib/library_version_analysis/version.rb
@@ -1,3 +1,3 @@
 module LibraryVersionAnalysis
-  VERSION = "2.0.2".freeze
+  VERSION = "2.0.3".freeze
 end


### PR DESCRIPTION
## What's in this PR?

Bumps the `library_version_analysis` gem version from `2.0.2` to `2.0.3`.

Part of the LIBTRACK-138 work; the analyzer JSON-parse fix lives in the companion [jobber-frontend PR](https://github.com/GetJobber/jobber-frontend/pull/12798).

## References

- https://jobber.atlassian.net/browse/LIBTRACK-138

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Amplify 2.1.4 <amplify@getjobber.com>