### PR TITLE
Require slack-ruby-client ~> 3.2

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -45,3 +45,6 @@
     Scope libyear-merged dependencies to the analyzed workspace so cross-workspace
     deps are no longer uploaded with blank versions (LIBTRACK-136). Distinguish an
     undeterminable resolved set (pnpm failure) from an empty one.
+
+2.0.4
+    Require slack-ruby-client ~> 3.2.

--- a/lib/library_version_analysis/version.rb
+++ b/lib/library_version_analysis/version.rb
@@ -1,3 +1,3 @@
 module LibraryVersionAnalysis
-  VERSION = "2.0.3".freeze
+  VERSION = "2.0.4".freeze
 end

--- a/library_version_analysis.gemspec
+++ b/library_version_analysis.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "libyear-bundler"
   spec.add_dependency "open3"
   spec.add_dependency "pry", "~> 0.16.0"
-  spec.add_dependency "slack-ruby-client"
+  spec.add_dependency "slack-ruby-client", "~> 3.2"
   spec.add_dependency "code_ownership"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rspec", "~> 3.2"


### PR DESCRIPTION
## What's in this PR?

Pins `slack-ruby-client` to `~> 3.2` in the gemspec (previously unconstrained) and bumps the gem version to 2.0.4, so consuming repos pick up the current Slack client by updating this library rather than pinning it themselves. This follows the review discussion on GetJobber/jobber-frontend#14346 — once this is released, jobber-frontend will move its git tag to v2.0.4 and drop the direct lockfile pin.

One caveat worth knowing before release: Jobber (the monolith) consumes this gem at v2.0.2 and is stuck on `slack-ruby-client` 1.0.0 — every later release requires faraday 2, which Jobber can't take while `elasticsearch-transport` (capped at 7.13.x by the prod AWS ES 7.10.2 OSS domain) requires faraday 1.x. With this constraint, Jobber stays on v2.0.2 until its legacy Elasticsearch stack migrates to OpenSearch. That's already the status quo; noting it so the constraint choice is deliberate.

## QA Instructions

- Bundling this gem resolves `slack-ruby-client` to 3.2.0; there are no dependency or API changes between 3.1.x and 3.2.0 that affect how this library posts to Slack.
- Full spec suite passes locally on Ruby 3.4 (126 examples, 0 failures); CI runs the same suite on 3.3.6.

## References

- GetJobber/jobber-frontend#14346 (review discussion prompting this change)
- [slack-ruby-client changelog](https://github.com/slack-ruby/slack-ruby-client/blob/master/CHANGELOG.md)

Co-Authored-By: Amplify 3.0.1 <amplify@getjobber.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
